### PR TITLE
Medium difficulty

### DIFF
--- a/MotorsportsPhysics/Components/Pages/CorneringQuiz.razor
+++ b/MotorsportsPhysics/Components/Pages/CorneringQuiz.razor
@@ -224,6 +224,8 @@ else
   [Parameter] public bool ShowExplanation { get; set; } = true;
   [Parameter] public bool RaceMode { get; set; } = false;
   [Parameter] public bool Timed { get; set; } = false;
+  // Difficulty label passed by parent (e.g., "Easy", "Medium", "High"). Default Easy.
+  [Parameter] public string Difficulty { get; set; } = "Easy";
   // When true (default), the quiz in StepMode will auto-start on first render.
   // Set to false to defer starting until the parent explicitly calls StartFromParent().
   [Parameter] public bool AutoStart { get; set; } = true;
@@ -259,7 +261,11 @@ else
   // Tracks which question IDs have been explicitly submitted (via Check answer) in StepMode
   private HashSet<int> committed = new();
 
-  private readonly List<Question> questions = new()
+  // The active list of questions for the current difficulty
+  private List<Question> questions = new();
+
+  // Easy (and default) question set
+  private readonly List<Question> _easyQuestions = new()
   {
     new(1, "What is the difference between understeer and oversteer?",
       new() {
@@ -311,6 +317,90 @@ else
     new(10, "Why do racing drivers take a “racing line” through corners?",
       new() { "A) To make the corner longer, reducing sharpness", "B) To stay closer to the audience", "C) To save tire life", "D) To reduce the need for braking completely" }, 0,
       explanationHtml: "A wider radius reduces required lateral acceleration (m v^2 / r), enabling higher corner speed and stability."),
+  };
+
+  // Medium question set (user-provided list)
+  private readonly List<Question> _mediumQuestions = new()
+  {
+    new(1, "What does the term \"slip angle\" describe in cornering?",
+      new() {
+        "A) The angle between the car’s direction of travel and the steering wheel position",
+        "B) The angle between the tire’s actual path and its pointing direction",
+        "C) The angle of the car’s roll while cornering",
+        "D) The maximum angle a car can turn before skidding"
+      }, 1),
+
+    new(2, "What happens when a driver enters a corner too fast?",
+      new() {
+        "A) The car always spins",
+        "B) The car tends to understeer or oversteer, depending on grip",
+        "C) The car automatically stabilizes due to inertia",
+        "D) The tires gain more grip"
+      }, 1),
+
+    new(3, "Why is the apex important when taking a racing corner?",
+      new() {
+        "A) It is the point where braking starts",
+        "B) It minimizes the steering input needed",
+        "C) It reduces engine wear",
+        "D)  It is the point closest to the inside of the corner that helps optimize speed"
+      }, 3),
+
+    new(4, "What is trail braking in racing?",
+      new() {
+        "A) Braking only before the corner",
+        "B) Braking throughout the entire straight",
+        "C) Gradually releasing the brake while entering the corner",
+        "D) Using the handbrake to initiate cornering"
+      }, 2),
+
+    new(5, "Which of these factors increases cornering grip?",
+      new() {
+        "A) Increased aerodynamic downforce",
+        "B) Lower car mass",
+        "C)  Higher tire pressure",
+        "D) Shorter wheelbase"
+      }, 0),
+
+    new(6, "What happens to lateral acceleration when corner radius decreases but speed stays the same?",
+      new() {
+        "A) It decreases",
+        "B) It increases",
+        "C) It stays the same",
+        "D) It becomes zero"
+      }, 1),
+
+    new(7, "What role does camber angle play in cornering?",
+      new() {
+        "A) It affects tire temperature",
+        "B) It reduces braking distance",
+        "C) It optimizes tire contact patch for better grip",
+        "D) It increases aerodynamic drag"
+      }, 2),
+
+    new(8, "Why do cars lean outward during a turn?",
+      new() {
+        "A) Due to aerodynamic forces",
+        "B) Due to centrifugal effect (inertia)",
+        "C) Due to reduced tire pressure",
+        "D) Due to suspension stiffness"
+      }, 1),
+
+    new(9, "Which cornering technique helps maintain maximum speed through a curve?",
+      new() {
+        "A) Braking late and accelerating early",
+        "B) Taking a wide entry, hitting the apex, and wide exit",
+        "C) Steering sharply into the corner",
+        "D) Reducing steering angle completely"
+      }, 1),
+
+    new(10, "Why is tire load sensitivity important in cornering?",
+      new() {
+        "A) Because tires generate more grip as load increases, but not proportionally",
+        "B) Because tires lose grip with increased load",
+        "C) Because load has no effect on grip",
+        "D) Because load sensitivity only applies to braking"
+      }, 0),
   };
 
   private void Select(int id, int optionIndex)
@@ -503,6 +593,17 @@ else
       ResetAndStart();
     }
     base.OnAfterRender(firstRender);
+  }
+
+  protected override void OnParametersSet()
+  {
+    // Select questions based on difficulty; default to Easy for unknown values.
+    var d = (Difficulty ?? "Easy").Trim();
+    var isMedium = d.Equals("Medium", StringComparison.OrdinalIgnoreCase);
+    var isEasy = d.Equals("Easy", StringComparison.OrdinalIgnoreCase);
+    // High currently uses Easy questions unless a separate set is added later
+    questions = isMedium ? _mediumQuestions : _easyQuestions;
+    base.OnParametersSet();
   }
 
   public void Dispose()

--- a/MotorsportsPhysics/Components/Pages/CorneringQuiz.razor
+++ b/MotorsportsPhysics/Components/Pages/CorneringQuiz.razor
@@ -600,7 +600,6 @@ else
     // Select questions based on difficulty; default to Easy for unknown values.
     var d = (Difficulty ?? "Easy").Trim();
     var isMedium = d.Equals("Medium", StringComparison.OrdinalIgnoreCase);
-    var isEasy = d.Equals("Easy", StringComparison.OrdinalIgnoreCase);
     // High currently uses Easy questions unless a separate set is added later
     questions = isMedium ? _mediumQuestions : _easyQuestions;
     base.OnParametersSet();

--- a/MotorsportsPhysics/Components/Pages/CorneringQuiz.razor
+++ b/MotorsportsPhysics/Components/Pages/CorneringQuiz.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Forms
 @implements IDisposable
+@using System.Linq
 
 <PageTitle>Cornering Dynamics Quiz</PageTitle>
 
@@ -105,11 +106,14 @@ else
         <div class="space-y-2 mb-4">
           @for (int i = 0; i < foes.Length; i++)
           {
+            var label = (RivalLabels is not null && i < RivalLabels.Length && !string.IsNullOrWhiteSpace(RivalLabels[i]))
+              ? RivalLabels[i]
+              : $"Rival {i+1}";
             <div class="flex items-center gap-2">
               <div class="flex-1 h-2 rounded-full bg-gray-200 overflow-hidden">
                 <div class="h-full bg-gray-500" style=@($"width:{Math.Round(foes[i]*100)}%")></div>
               </div>
-              <span class="text-xs text-gray-500">Rival @(@i+1)</span>
+              <span class="text-xs text-gray-500">@label</span>
             </div>
           }
         </div>
@@ -165,9 +169,11 @@ else
         }
         else
         {
-          <button class="w-full md:w-auto flex min-w-[120px] items-center justify-center rounded-lg h-11 px-6 bg-primary text-white text-sm font-bold tracking-wider"
-                  @onclick="Next">
-            <span>@(current < questions.Count - 1 ? "Next" : "Finish")</span>
+          var isLast = current >= questions.Count - 1;
+          var canFinish = !RaceMode || !isLast || (userProgress >= 0.999 && foes.All(f => f >= 0.999));
+          <button class="w-full md:w-auto flex min-w-[120px] items-center justify-center rounded-lg h-11 px-6 bg-primary text-white text-sm font-bold tracking-wider disabled:opacity-50"
+                  disabled="@(!canFinish)" @onclick="Next">
+            <span>@(isLast ? "Finish" : "Next")</span>
           </button>
         }
       </div>
@@ -187,10 +193,21 @@ else
       }
       @if (RaceMode)
       {
-        var placement = 1 + foes.Count(f => f > userProgress);
-        <p class="mt-2 text-gray-800 font-medium">
-          Race result: @(placement == 1 ? "You won!" : $"You finished {placement} of {foes.Length + 1}")
-        </p>
+            if (_externalPlacement.HasValue)
+            {
+              var pos = _externalPlacement!.Value;
+              var tot = Math.Max(1, _externalTotalCars > 0 ? _externalTotalCars : foes.Length + 1);
+              <p class="mt-2 text-gray-800 font-medium">
+                Race result: @(pos == 1 ? "You won!" : $"You finished {pos} of {tot}")
+              </p>
+            }
+            else
+            {
+              var placement = 1 + foes.Count(f => f > userProgress);
+              <p class="mt-2 text-gray-800 font-medium">
+                Race result: @(placement == 1 ? "You won!" : $"You finished {placement} of {foes.Length + 1}")
+              </p>
+            }
       }
       <div class="mt-4 flex justify-center gap-3">
         <button class="rounded-lg border px-4 py-2 font-semibold hover:bg-gray-50" @onclick="ResetAndStart">Try again</button>
@@ -229,11 +246,15 @@ else
   private DateTime? _finishedUtc;
   private TimeSpan? _elapsed;
   private bool _showElapsed = false;
+  private int? _externalPlacement;
+  private int _externalTotalCars = 0;
   private int timeLeft;
   private System.Timers.Timer? _timer;
   private double userProgress = 0; // 0..1
-  private double[] foes = new double[2] { 0, 0 };
-  private double[] foeBase = new double[2] { 0.9, 0.8 }; // relative pace per question step
+  [Parameter] public string[] RivalLabels { get; set; } = System.Array.Empty<string>();
+  // Five rivals' relative progress (0..1) and per-step base pace multipliers (matches Medium race cars)
+  private double[] foes = new double[5] { 0, 0, 0, 0, 0 };
+  private double[] foeBase = new double[5] { 0.95, 0.92, 0.90, 0.88, 0.85 }; // relative pace per question step
   private readonly Random _rng = new Random();
   // Tracks which question IDs have been explicitly submitted (via Check answer) in StepMode
   private HashSet<int> committed = new();
@@ -343,6 +364,8 @@ else
     submitted = false;
     answers.Clear();
     committed.Clear();
+    _externalPlacement = null;
+    _externalTotalCars = 0;
   }
 
   private void ResetAndStart()
@@ -354,7 +377,7 @@ else
     _startedUtc = DateTime.UtcNow;
     _finishedUtc = null;
     _elapsed = null;
-    userProgress = 0; foes[0] = foes[1] = 0; started = true;
+  userProgress = 0; for (int i = 0; i < foes.Length; i++) foes[i] = 0; started = true;
     if (Timed)
     {
       StartTimer();
@@ -458,6 +481,21 @@ else
     }
   }
 
+  // --- External race integration helpers ---
+  public int GetTotalSteps() => questions.Count;
+  public int GetFoeCount() => foes.Length;
+  private static double Clamp01(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
+  public void SetExternalProgress(double youFraction, IReadOnlyList<double> rivalsFractions)
+  {
+    userProgress = Clamp01(youFraction);
+    for (int i = 0; i < foes.Length; i++)
+    {
+      var f = (i < rivalsFractions.Count) ? rivalsFractions[i] : 0.0;
+      foes[i] = Clamp01(f);
+    }
+    InvokeAsync(StateHasChanged);
+  }
+
   protected override void OnAfterRender(bool firstRender)
   {
     if (firstRender && StepMode && !started && AutoStart)
@@ -508,6 +546,14 @@ else
   {
     _elapsed = elapsed;
     _showElapsed = true;
+    InvokeAsync(StateHasChanged);
+  }
+
+  // Called by parent to set the authoritative final placement from the race engine
+  public void SetExternalPlacement(int position, int totalCars)
+  {
+    _externalPlacement = position;
+    _externalTotalCars = totalCars;
     InvokeAsync(StateHasChanged);
   }
 

--- a/MotorsportsPhysics/Components/Pages/RaceMenu.razor
+++ b/MotorsportsPhysics/Components/Pages/RaceMenu.razor
@@ -18,7 +18,7 @@
 
     <div class="rounded-xl border border-primary/20 bg-white p-6 shadow-sm flex flex-col">
       <h2 class="text-xl font-semibold mb-2">Medium</h2>
-      <p class="text-gray-600 mb-4">Race rivals. Explanations on. No timer.</p>
+      <p class="text-gray-600 mb-4">Race five rivals. Explanations on. No timer. The car never stops for unanswered questions.</p>
       <a class="mt-auto inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 font-semibold text-white hover:bg-opacity-90"
          href="/race-quiz?difficulty=medium">Start</a>
     </div>

--- a/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
+++ b/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
@@ -26,11 +26,11 @@ else
       {
         @if (_isEasy)
         {
-          <EasyRace @ref="_easyRace" QuestionAnswered="@_questionAnswered" AnsweredCount="@_answeredCount" OnLapChanged="OnLapChanged" />
+          <EasyRace @ref="_easyRace" QuestionAnswered="@_questionAnswered" AnsweredCount="@_answeredCount" OnLapChanged="OnLapChanged" GateByAnsweredCount="true" />
         }
         else
         {
-          <MediumRace @ref="_mediumRace" QuestionAnswered="@_questionAnswered" AnsweredCount="@_answeredCount" OnLapChanged="OnLapChanged" />
+          <MediumRace @ref="_mediumRace" QuestionAnswered="@_questionAnswered" AnsweredCount="@_answeredCount" OnLapChanged="OnLapChanged" GateByAnsweredCount="false" />
         }
       }
   <CorneringQuiz @ref="_quizRef" StepMode="true" AutoStart="false" OnFinished="OnQuizFinished"

--- a/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
+++ b/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
@@ -158,6 +158,10 @@ else
     {
       await _easyRace.StartStepAsync(step);
     }
+    else if (!_isEasy && _mediumRace is not null)
+    {
+      await _mediumRace.StartStepAsync(step);
+    }
   }
 
   private Task OnAnswerStateChanged(bool answered)

--- a/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
+++ b/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
@@ -38,6 +38,7 @@ else
                    RaceMode="@_raceMode"
                    Timed="@_timed"
                    TimeLimitSeconds="@_timeLimit"
+                   Difficulty="@_label"
                    RivalLabels="@_rivalLabels"
                    OnStepStarted="OnStepStarted"
                    OnAnswerStateChanged="OnAnswerStateChanged"
@@ -49,12 +50,32 @@ else
       <div class="fixed inset-0 z-40 flex items-center justify-center bg-black/50">
         <div class="max-w-lg w-[92%] rounded-lg bg-white shadow-xl p-6">
           <h2 class="text-xl font-bold mb-3">How to play</h2>
-          <ul class="list-disc pl-5 text-gray-800 space-y-2 mb-4">
-            <li>Watch the car as it drives around the track. Answer the question shown for each step.</li>
-            <li>When you answer incorrectly in Easy mode, your car gets a temporary speed penalty.</li>
-            <li>Improve your pace by answering correctly — speed ramps up every lap.</li>
-          </ul>
-          <p class="text-gray-700 mb-5">Click OK to begin. The car will start after a short countdown.</p>
+          @if (_isEasy)
+          {
+            <ul class="list-disc pl-5 text-gray-800 space-y-2 mb-4">
+              <li>Watch the car as it drives around the track. Answer the question shown for each step.</li>
+              <li>Wrong answers give a temporary speed penalty.</li>
+              <li>Improve your pace by answering correctly — speed ramps up every lap.</li>
+            </ul>
+          }
+          else if (string.Equals(_label, "Medium", StringComparison.OrdinalIgnoreCase))
+          {
+            <ul class="list-disc pl-5 text-gray-800 space-y-2 mb-4">
+              <li>Race five rivals. Explanations are on. No timer.</li>
+              <li>Your car keeps moving even if you haven’t answered yet.</li>
+              <li>Answer correctly to boost your pace; wrong answers cause a brief slowdown.</li>
+              <li>Complete all questions. Your final placing is shown at the end.</li>
+            </ul>
+          }
+          else
+          {
+            <ul class="list-disc pl-5 text-gray-800 space-y-2 mb-4">
+              <li>Race rivals with a countdown. Explanations are off.</li>
+              <li>Answer quickly — correct answers improve your pace; wrong answers slow you briefly.</li>
+              <li>Finish all questions before time runs out.</li>
+            </ul>
+          }
+          <p class="text-gray-700 mb-5">Click OK to begin. The race will start after a short countdown.</p>
           <div class="flex justify-end gap-2">
             <button class="rounded-md border px-4 py-2" @onclick="() => _showDisclaimer = false">Cancel</button>
             <button class="rounded-md bg-primary text-white px-4 py-2" @onclick="BeginQuizAndRace">OK, let’s go</button>

--- a/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
+++ b/MotorsportsPhysics/Components/Pages/RaceQuiz.razor
@@ -38,6 +38,7 @@ else
                    RaceMode="@_raceMode"
                    Timed="@_timed"
                    TimeLimitSeconds="@_timeLimit"
+                   RivalLabels="@_rivalLabels"
                    OnStepStarted="OnStepStarted"
                    OnAnswerStateChanged="OnAnswerStateChanged"
                    OnAnswerChecked="OnAnswerChecked"
@@ -68,6 +69,7 @@ else
         <div class="rounded-xl bg-white shadow-2xl p-8 max-w-md w-[92%] text-center">
           <h2 class="text-2xl font-extrabold mb-2">Grand Prix finished</h2>
           <p class="text-gray-700 mb-4">Congratulations! You’ve completed all laps and questions.</p>
+          <p class="text-gray-700 mb-2">Your position: <strong>@_finalPosition</strong> / @_finalTotalCars</p>
           <p class="text-gray-600">The car is no longer riding.</p>
           <div class="mt-6 flex justify-center">
             <button class="rounded-md bg-primary text-white px-6 py-2 font-semibold" @onclick="() => _grandPrixFinished = false">OK</button>
@@ -101,6 +103,12 @@ else
   private DateTime? _raceStartedUtc;
   private DateTime? _raceFinishedUtc;
   private DateTime? _quizFinishedUtc;
+  private int _finalPosition = 1;
+  private int _finalTotalCars = 1;
+  private string[] _rivalLabels = System.Array.Empty<string>();
+  private List<RaceTrack.LapTelemetry> _telemetry = new();
+  private CancellationTokenSource? _progressPumpCts;
+  private const double WrongAnswerPenaltyDelta = -30; // px/s (milder penalty)
 
 
   protected override void OnInitialized()
@@ -127,6 +135,7 @@ else
         _label = "Medium";
         _isEasy = false;
           _showAnim = true;
+        _rivalLabels = new [] { "Blue", "Green", "Purple", "Orange", "Pink" };
         break;
       case "high":
         _showExplanation = false;
@@ -136,6 +145,7 @@ else
         _label = "High";
         _isEasy = false;
           _showAnim = true;
+        _rivalLabels = new [] { "Blue", "Green", "Purple", "Orange", "Pink" };
         break;
       default:
         _showExplanation = true;
@@ -145,6 +155,7 @@ else
         _label = "Easy";
         _isEasy = true;
         _showAnim = true;
+        _rivalLabels = System.Array.Empty<string>();
         break;
     }
     _configured = true;
@@ -156,12 +167,17 @@ else
     _raceStartedUtc ??= DateTime.UtcNow;
     if (_isEasy && _easyRace is not null)
     {
+      try { await _easyRace.ResetLapTelemetryAsync(); } catch { }
+      try { await _easyRace.SetTargetLapsAsync(_quizRef?.GetTotalSteps() ?? step); } catch { }
       await _easyRace.StartStepAsync(step);
     }
     else if (!_isEasy && _mediumRace is not null)
     {
+      try { await _mediumRace.ResetLapTelemetryAsync(); } catch { }
+      try { await _mediumRace.SetTargetLapsAsync(_quizRef?.GetTotalSteps() ?? step); } catch { }
       await _mediumRace.StartStepAsync(step);
     }
+    _ = UpdateProgressBarsFromRaceAsync();
   }
 
   private Task OnAnswerStateChanged(bool answered)
@@ -180,62 +196,115 @@ else
 
   private async Task OnAnswerChecked(bool correct)
   {
-    // Case 1 (correct): increase base speed immediately
-    if (_isEasy && _easyRace is not null && correct)
+    // Correct answer: increase base speed immediately (Easy & Medium)
+    if (correct)
     {
-      await _easyRace.AdjustBaseSpeedAsync(+35); // increased boost per request
+      if (_isEasy && _easyRace is not null)
+      {
+        await _easyRace.AdjustBaseSpeedAsync(+35);
+      }
+      else if (!_isEasy && _mediumRace is not null)
+      {
+        await _mediumRace.AdjustBaseSpeedAsync(+35);
+      }
     }
-    // Case 2 (wrong): decrease base speed immediately
-    else if (_isEasy && _easyRace is not null && !correct)
+    // Incorrect answer: set absolute base speed to 50 px/s (Easy & Medium)
+    else
     {
-      await _easyRace.AdjustBaseSpeedAsync(-15); // tune as desired
+      if (_isEasy && _easyRace is not null)
+      {
+        await _easyRace.AdjustBaseSpeedAsync(WrongAnswerPenaltyDelta);
+      }
+      else if (!_isEasy && _mediumRace is not null)
+      {
+        await _mediumRace.AdjustBaseSpeedAsync(WrongAnswerPenaltyDelta);
+      }
     }
   }
 
   private Task OnQuizFinished()
   {
     _quizFinishedUtc = DateTime.UtcNow;
-    // If the car has already completed the final lap (lapCounter >= answered count), reveal immediately
     if (_answeredCount > 0 && _lastLapSeen >= _answeredCount)
     {
-      // Compute max(quiz, car)
       var quizElapsed = (_raceStartedUtc.HasValue && _quizFinishedUtc.HasValue) ? (_quizFinishedUtc.Value - _raceStartedUtc.Value) : TimeSpan.Zero;
       var carElapsed = (_raceStartedUtc.HasValue && _raceFinishedUtc.HasValue) ? (_raceFinishedUtc.Value - _raceStartedUtc.Value) : quizElapsed;
       var maxElapsed = quizElapsed > carElapsed ? quizElapsed : carElapsed;
       try { _quizRef?.RevealElapsedWith(maxElapsed); } catch { }
-      // Ensure car is stopped and overlay is shown if needed
-      _ = StopCarAsync();
       _grandPrixFinished = true;
+  StopProgressPump();
+      _ = StopCarAsync();
+      _ = CaptureFinalRankAsync();
       StateHasChanged();
       _quizFinished = false;
     }
     else
     {
-      _quizFinished = true; // wait for OnLapChanged to signal the final crossing
+      _quizFinished = true;
     }
     return Task.CompletedTask;
   }
 
-  private Task OnLapChanged(int lap)
+  private async Task OnLapChanged(int lap)
   {
     _lastLapSeen = lap;
-    // When the quiz is finished, wait for exactly 'AnsweredCount' laps to be completed, then mark race finished
-    // Note: lap is 0-based internally; AnsweredCount is the number of questions answered (1-based threshold)
+    // Refresh progress bars on each lap crossing
+    await UpdateProgressBarsFromRaceAsync();
+    // Pull and store updated per-lap telemetry
+    try
+    {
+      List<RaceTrack.LapTelemetry> snaps = new();
+      if (_isEasy && _easyRace is not null) snaps = await _easyRace.GetLapTelemetryAsync();
+      else if (!_isEasy && _mediumRace is not null) snaps = await _mediumRace.GetLapTelemetryAsync();
+      if (snaps.Count > 0)
+      {
+        // Ensure we keep unique lap numbers, append new ones only
+        var known = new HashSet<int>(_telemetry.Select(t => t.Lap));
+        foreach (var t in snaps.OrderBy(s => s.Lap))
+        {
+          if (known.Add(t.Lap)) _telemetry.Add(t);
+        }
+      }
+    }
+    catch { }
     if (_quizFinished && _answeredCount > 0 && lap >= _answeredCount)
     {
-      _quizFinished = false; // prevent duplicate calls
+      _quizFinished = false;
       _raceFinishedUtc ??= DateTime.UtcNow;
-      // Compute max(quiz, car)
       var quizElapsed = (_raceStartedUtc.HasValue && _quizFinishedUtc.HasValue) ? (_quizFinishedUtc.Value - _raceStartedUtc.Value) : TimeSpan.Zero;
       var carElapsed = (_raceStartedUtc.HasValue && _raceFinishedUtc.HasValue) ? (_raceFinishedUtc.Value - _raceStartedUtc.Value) : quizElapsed;
       var maxElapsed = quizElapsed > carElapsed ? quizElapsed : carElapsed;
       try { _quizRef?.RevealElapsedWith(maxElapsed); } catch { }
-      // Stop the car and show the finish overlay
-      _ = StopCarAsync();
       _grandPrixFinished = true;
+      StopProgressPump();
+      _ = StopCarAsync();
+      _ = CaptureFinalRankAsync();
       StateHasChanged();
     }
-    return Task.CompletedTask;
+    return;
+  }
+
+  private async Task CaptureFinalRankAsync()
+  {
+    if (!_grandPrixFinished) return; // don't compute final position until race is over
+    try
+    {
+      if (_isEasy && _easyRace is not null)
+      {
+        var r = await _easyRace.GetUserRankAsync();
+        _finalPosition = r.Position;
+        _finalTotalCars = r.TotalCars;
+      }
+      else if (!_isEasy && _mediumRace is not null)
+      {
+        var r = await _mediumRace.GetUserRankAsync();
+        _finalPosition = r.Position;
+        _finalTotalCars = r.TotalCars;
+      }
+      try { _quizRef?.SetExternalPlacement(_finalPosition, _finalTotalCars); } catch { }
+      StateHasChanged();
+    }
+    catch { }
   }
 
   private async Task StopCarAsync()
@@ -254,8 +323,86 @@ else
     StateHasChanged();
     // Defer to next render to ensure overlays are gone before starting
     await Task.Yield();
+    try {
+      if (_isEasy && _easyRace is not null) await _easyRace.ResetLapTelemetryAsync();
+      else if (!_isEasy && _mediumRace is not null) await _mediumRace.ResetLapTelemetryAsync();
+    } catch { }
+    // Set planned laps before the first step kicks in
+    try {
+      var total = _quizRef?.GetTotalSteps() ?? 0;
+      if (total > 0)
+      {
+        if (_isEasy && _easyRace is not null) await _easyRace.SetTargetLapsAsync(total);
+        else if (!_isEasy && _mediumRace is not null) await _mediumRace.SetTargetLapsAsync(total);
+      }
+    } catch { }
     // Start the quiz flow; it will trigger OnStepStarted(1) and then start the race step via _easyRace
     _quizRef?.StartFromParent();
+    _ = UpdateProgressBarsFromRaceAsync();
+    StartProgressPump();
     _raceStartedUtc ??= DateTime.UtcNow;
+  }
+
+  private async Task UpdateProgressBarsFromRaceAsync()
+  {
+    try
+    {
+      var rivals = new List<double>();
+      double you = 0;
+      if (_isEasy && _easyRace is not null)
+      {
+        var ds = await _easyRace.GetCoveredDistancesAsync();
+        var u = ds.FirstOrDefault(d => d.IsUser);
+        you = Math.Clamp(u?.FractionOfRace ?? 0, 0, 1);
+      }
+      else if (!_isEasy && _mediumRace is not null)
+      {
+        var ds = await _mediumRace.GetCoveredDistancesAsync();
+        var u = ds.FirstOrDefault(d => d.IsUser);
+        you = Math.Clamp(u?.FractionOfRace ?? 0, 0, 1);
+        var foes = ds.Where(d => !d.IsUser).OrderBy(d => d.Idx).ToList();
+        var want = _quizRef?.GetFoeCount() ?? 5;
+        for (int i = 0; i < want; i++)
+        {
+          var f = (i < foes.Count) ? (foes[i].FractionOfRace ?? 0) : 0;
+          rivals.Add(Math.Clamp(f, 0, 1));
+        }
+      }
+      _quizRef?.SetExternalProgress(you, rivals);
+    }
+    catch { }
+  }
+
+  private void StartProgressPump()
+  {
+    try { StopProgressPump(); } catch { }
+    _progressPumpCts = new CancellationTokenSource();
+    var ct = _progressPumpCts.Token;
+    _ = Task.Run(async () =>
+    {
+      try
+      {
+        while (!ct.IsCancellationRequested)
+        {
+          if (_grandPrixFinished) break;
+          await InvokeAsync(UpdateProgressBarsFromRaceAsync);
+          await Task.Delay(500, ct);
+        }
+      }
+      catch (OperationCanceledException) { }
+      catch { }
+    }, ct);
+  }
+
+  private void StopProgressPump()
+  {
+    try { _progressPumpCts?.Cancel(); } catch { }
+    try { _progressPumpCts?.Dispose(); } catch { }
+    _progressPumpCts = null;
+  }
+
+  public void Dispose()
+  {
+    StopProgressPump();
   }
 }

--- a/MotorsportsPhysics/Components/Shared/EasyRace.razor
+++ b/MotorsportsPhysics/Components/Shared/EasyRace.razor
@@ -36,6 +36,12 @@
     await track.AdjustBaseSpeedAsync(delta);
   }
 
+  public async Task SetBaseSpeedAsync(double absolute)
+  {
+    if (track is null) return;
+    await track.SetBaseSpeedAsync(absolute);
+  }
+
   public async Task StartAsync(double? targetSpeed = null)
   {
     if (track is null) return;
@@ -46,5 +52,35 @@
   {
     if (track is null) return;
     await track.StopAsync();
+  }
+
+  public async Task<RaceTrack.RaceRank> GetUserRankAsync()
+  {
+    if (track is null) return new RaceTrack.RaceRank(1, 1);
+    return await track.GetUserRankAsync();
+  }
+
+  public async Task<List<RaceTrack.CoveredDistance>> GetCoveredDistancesAsync()
+  {
+    if (track is null) return new List<RaceTrack.CoveredDistance>();
+    return await track.GetCoveredDistancesAsync();
+  }
+
+  public async Task SetTargetLapsAsync(int laps)
+  {
+    if (track is null) return;
+    await track.SetTargetLapsAsync(laps);
+  }
+
+  public async Task<List<RaceTrack.LapTelemetry>> GetLapTelemetryAsync()
+  {
+    if (track is null) return new List<RaceTrack.LapTelemetry>();
+    return await track.GetLapTelemetryAsync();
+  }
+
+  public async Task ResetLapTelemetryAsync()
+  {
+    if (track is null) return;
+    await track.ResetLapTelemetryAsync();
   }
 }

--- a/MotorsportsPhysics/Components/Shared/EasyRace.razor
+++ b/MotorsportsPhysics/Components/Shared/EasyRace.razor
@@ -1,7 +1,7 @@
 @using MotorsportsPhysics.Components.Shared
 
 <RaceTrack @ref="track" Class="mb-8" Title="Cornering Dynamics" AutoStart="false"
-  QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged"
+  QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged" GateByAnsweredCount="@GateByAnsweredCount"
   Cars="@(new MotorsportsPhysics.Components.Shared.RaceTrack.CarSprite[] { new MotorsportsPhysics.Components.Shared.RaceTrack.CarSprite("images/car-yellow.png", 70, 40, 0.0) })" />
 
 @code {
@@ -9,6 +9,8 @@
   [Parameter] public bool QuestionAnswered { get; set; } = false;
   [Parameter] public int AnsweredCount { get; set; } = 0;
   [Parameter] public EventCallback<int> OnLapChanged { get; set; }
+  // Easy mode: keep gating enabled by default
+  [Parameter] public bool GateByAnsweredCount { get; set; } = true;
 
   public async Task StartStepAsync(int step)//ilove cats and my sister, give me million dollars pls
   {

--- a/MotorsportsPhysics/Components/Shared/MediumRace.razor
+++ b/MotorsportsPhysics/Components/Shared/MediumRace.razor
@@ -1,6 +1,6 @@
 @using MotorsportsPhysics.Components.Shared
 
-<RaceTrack @ref="track" Class="mb-8" Title="Cornering Dynamics" AutoStart="false" ShowPath="true" QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged"
+<RaceTrack @ref="track" Class="mb-8" Title="Cornering Dynamics" AutoStart="false" ShowPath="true" QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged" GateByAnsweredCount="@GateByAnsweredCount"
   Cars="@(new RaceTrack.CarSprite[] {
     // Offset along path, then fine X/Y grid deltas
     // Offset along path (0..1), then GridDx and GridDy (in px) to fine-tune sprite placement
@@ -20,6 +20,8 @@
   [Parameter] public bool QuestionAnswered { get; set; } = false;
   [Parameter] public int AnsweredCount { get; set; } = 0;
   [Parameter] public EventCallback<int> OnLapChanged { get; set; }
+  // Medium mode: disable lap-to-question gating by default
+  [Parameter] public bool GateByAnsweredCount { get; set; } = false;
 
   public async Task StartStepAsync(int step)
   {

--- a/MotorsportsPhysics/Components/Shared/MediumRace.razor
+++ b/MotorsportsPhysics/Components/Shared/MediumRace.razor
@@ -51,4 +51,40 @@
     if (track is null) return;
     await track.ApplyPenaltyForNextLapAsync(multiplier);
   }
+
+  public async Task<RaceTrack.RaceRank> GetUserRankAsync()
+  {
+    if (track is null) return new RaceTrack.RaceRank(1, 1);
+    return await track.GetUserRankAsync();
+  }
+
+  public async Task SetBaseSpeedAsync(double absolute)
+  {
+    if (track is null) return;
+    await track.SetBaseSpeedAsync(absolute);
+  }
+
+  public async Task<List<RaceTrack.CoveredDistance>> GetCoveredDistancesAsync()
+  {
+    if (track is null) return new List<RaceTrack.CoveredDistance>();
+    return await track.GetCoveredDistancesAsync();
+  }
+
+  public async Task SetTargetLapsAsync(int laps)
+  {
+    if (track is null) return;
+    await track.SetTargetLapsAsync(laps);
+  }
+
+  public async Task<List<RaceTrack.LapTelemetry>> GetLapTelemetryAsync()
+  {
+    if (track is null) return new List<RaceTrack.LapTelemetry>();
+    return await track.GetLapTelemetryAsync();
+  }
+
+  public async Task ResetLapTelemetryAsync()
+  {
+    if (track is null) return;
+    await track.ResetLapTelemetryAsync();
+  }
 }

--- a/MotorsportsPhysics/Components/Shared/MediumRace.razor
+++ b/MotorsportsPhysics/Components/Shared/MediumRace.razor
@@ -1,6 +1,6 @@
 @using MotorsportsPhysics.Components.Shared
 
-<RaceTrack @ref="track" Class="mb-8" Title="Cornering Dynamics" AutoStart="false" ShowPath="true" QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged" GateByAnsweredCount="@GateByAnsweredCount"
+<RaceTrack @ref="track" Class="mb-8" Title="Cornering Dynamics" AutoStart="false" QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged" GateByAnsweredCount="@GateByAnsweredCount"
   Cars="@(new RaceTrack.CarSprite[] {
     // Offset along path, then fine X/Y grid deltas
     // Offset along path (0..1), then GridDx and GridDy (in px) to fine-tune sprite placement

--- a/MotorsportsPhysics/Components/Shared/MediumRace.razor
+++ b/MotorsportsPhysics/Components/Shared/MediumRace.razor
@@ -1,11 +1,18 @@
 @using MotorsportsPhysics.Components.Shared
 
-<RaceTrack @ref="track" Class="mb-8" Title="Cornering Dynamics" PathTranslateX="50" AutoStart="false" QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged"
+<RaceTrack @ref="track" Class="mb-8" Title="Cornering Dynamics" AutoStart="false" ShowPath="true" QuestionAnswered="@QuestionAnswered" AnsweredCount="@AnsweredCount" OnLapChangedEvent="@OnLapChanged"
   Cars="@(new RaceTrack.CarSprite[] {
-    new RaceTrack.CarSprite("images/car-yellow.png", 70, 40, 0.00),
-    new RaceTrack.CarSprite("images/car-blue.png",   70, 40, 0.20),
-    new RaceTrack.CarSprite("images/car-green.png",  70, 40, 0.40),
-    new RaceTrack.CarSprite("images/car-purple.png", 70, 40, 0.60)
+    // Offset along path, then fine X/Y grid deltas
+    // Offset along path (0..1), then GridDx and GridDy (in px) to fine-tune sprite placement
+    // Upper-lane cars (gridDy=0) must share EXACT same path coordinates; only offsets vary
+    new RaceTrack.CarSprite("images/car-yellow.png", 70, 40, 0.000, 0, 0),
+    new RaceTrack.CarSprite("images/car-blue.png",   70, 40, -0.025, 0, 0),
+    new RaceTrack.CarSprite("images/car-green.png",  70, 40, -0.050, 0, 0),
+    // Lower-lane cars: EXACT SAME TRAJECTORY among themselves; only start offsets differ.
+    // Use explicit Lane=2 and zero grid deltas so they share identical coordinates.
+    new RaceTrack.CarSprite("images/car-purple.png", 70, 40, -0.008, 0, 0, 2),
+    new RaceTrack.CarSprite("images/car-orange.png", 70, 40, -0.031, 0, 0, 2),
+    new RaceTrack.CarSprite("images/car-pink.png",   70, 40, -0.056, 0, 0, 2)
   })" />
 
 @code {
@@ -13,6 +20,13 @@
   [Parameter] public bool QuestionAnswered { get; set; } = false;
   [Parameter] public int AnsweredCount { get; set; } = 0;
   [Parameter] public EventCallback<int> OnLapChanged { get; set; }
+
+  public async Task StartStepAsync(int step)
+  {
+    if (track is null) { await Task.CompletedTask; return; }
+    var laps = Math.Max(1, step); // visual progression only
+    await track.PlayLapsAsync(1, speed: null, haltOnFinish: false);
+  }
 
   public async Task StartAsync(double? targetSpeed = null)
   {

--- a/MotorsportsPhysics/Components/Shared/RaceTrack.razor
+++ b/MotorsportsPhysics/Components/Shared/RaceTrack.razor
@@ -18,6 +18,17 @@
     transform="@(((PathScaleX != 1.0 || PathScaleY != 1.0) && PathScale == 1.0 && PathTranslateX == 0 && PathTranslateY == 0)
       ? $"scale({PathScaleX.ToString(System.Globalization.CultureInfo.InvariantCulture)} {PathScaleY.ToString(System.Globalization.CultureInfo.InvariantCulture)})"
       : null)" />
+      <!-- Secondary lane path (same styling/visibility) -->
+      <path id="racePath2"
+        d="@PathD2"
+        fill="none"
+        stroke="@PathColor"
+        stroke-width="@((ShowPath ? PathWidth : 0).ToString(System.Globalization.CultureInfo.InvariantCulture))"
+        stroke-opacity="@((ShowPath ? PathOpacity : 0).ToString(System.Globalization.CultureInfo.InvariantCulture))"
+        stroke-dasharray="@(ShowPath && !string.IsNullOrEmpty(PathDashArray) ? PathDashArray : null)"
+        transform="@(((PathScaleX != 1.0 || PathScaleY != 1.0) && PathScale == 1.0 && PathTranslateX == 0 && PathTranslateY == 0)
+          ? $"scale({PathScaleX.ToString(System.Globalization.CultureInfo.InvariantCulture)} {PathScaleY.ToString(System.Globalization.CultureInfo.InvariantCulture)})"
+          : null)" />
       @if (Cars?.Any() == true)
       {
         var idx = 0;
@@ -25,11 +36,11 @@
         {
           if (idx == 0)
           {
-            <image id="carSprite" class="carSprite" href="@car.Src" width="@car.Width" height="@car.Height" data-offset="@car.Offset.ToString(System.Globalization.CultureInfo.InvariantCulture)" />
+            <image id="carSprite" class="carSprite" href="@car.Src" width="@car.Width" height="@car.Height" data-offset="@car.Offset.ToString(System.Globalization.CultureInfo.InvariantCulture)" data-grid-dx="@car.GridDx.ToString(System.Globalization.CultureInfo.InvariantCulture)" data-grid-dy="@car.GridDy.ToString(System.Globalization.CultureInfo.InvariantCulture)" data-lane="@car.Lane" />
           }
           else
           {
-            <image class="carSprite" href="@car.Src" width="@car.Width" height="@car.Height" data-offset="@car.Offset.ToString(System.Globalization.CultureInfo.InvariantCulture)" />
+            <image class="carSprite" href="@car.Src" width="@car.Width" height="@car.Height" data-offset="@car.Offset.ToString(System.Globalization.CultureInfo.InvariantCulture)" data-grid-dx="@car.GridDx.ToString(System.Globalization.CultureInfo.InvariantCulture)" data-grid-dy="@car.GridDy.ToString(System.Globalization.CultureInfo.InvariantCulture)" data-lane="@car.Lane" />
           }
           idx++;
         }
@@ -110,7 +121,7 @@
   protected override async Task OnAfterRenderAsync(bool firstRender)
   {
     if (!firstRender) return;
-  _module = await JS.InvokeAsync<IJSObjectReference>("import", "/js/trackSim.js?v=13");
+  _module = await JS.InvokeAsync<IJSObjectReference>("import", "/js/trackSim.js?v=18");
   _anim = await _module.InvokeAsync<IJSObjectReference>("init", svg, new { speed = this.Speed, startRotation = this.StartRotation, angleSmoothing = this.AngleSmoothing, startOffsetFrac = this.StartOffsetFraction, showStartMarker = this.ShowStartMarker });
     // Apply optional transform so the path and cars align
     if (_anim is not null && (PathTranslateX != 0 || PathTranslateY != 0 || Math.Abs(PathScale - 1.0) > double.Epsilon))
@@ -220,7 +231,7 @@
     _selfRef = null;
   }
 
-  public record CarSprite(string Src, double Width = 70, double Height = 40, double Offset = 0);
+  public record CarSprite(string Src, double Width = 70, double Height = 40, double Offset = 0, double GridDx = 0, double GridDy = 0, int Lane = 1);
 
   [Parameter] public bool ShowStartMarker { get; set; } = false;
 
@@ -230,6 +241,10 @@
   [Parameter] public double PathScale { get; set; } = 0.77;
   [Parameter] public double PathTranslateX { get; set; } = 130.0;
   [Parameter] public double PathTranslateY { get; set; } = 39.0;
+
+  // Secondary lane path data (before transform). Uses the provided alternate SVG path.
+  private string PathD2 =
+    "M612.508 423.151C438.898 431.914 342.384 437.99 157.525 430.869L105.314 425.08C75.8902 420.87 59.5932 415.586 30.7261 403.212C12.8274 390.524 7.28976 383.829 2.24728 372.338C-0.27815 353.794 0.792105 343.641 7.67182 326.028C12.3987 316.855 17.2131 311.847 35.4726 303.516C52.7043 299.586 62.4797 297.497 89.718 303.516C96.542 306.243 106.791 307.804 146.5 331.817C166.384 343.332 177.263 349.483 198 352.399C226.409 352.638 241.088 356.2 271.44 352.399C288.644 345.87 298.524 342.547 312.802 331.817C323.327 322.255 329.179 316.875 336.535 306.089C340.464 295.427 342.557 289.419 345.35 278.432C348.644 263.111 348.231 253.314 345.35 234.694C336.411 223.188 329.636 217.788 316.193 208.966C301.988 200.751 291.955 196.688 270.762 190.314C238.172 177.054 220.704 168.949 192.106 152.365C181.637 146.763 176.722 142.797 171.764 132.426C166.247 122.447 164.651 116.989 164.5 107.5C161.777 93.8316 162.108 86.1684 164.5 72.5C168.373 53.6485 179.604 47.1064 198.209 34.0172C229.62 14.5551 250.567 9.50283 289.07 2.50056C322.807 -0.953666 340.821 2.07071 373.15 6.35973C383.933 9.79361 389.701 12.0692 407.054 20.51C415.291 26.2583 427.178 28.946 435.5 51.5C435.5 51.5 438.245 79 438.245 89V89.2674C438.244 99.6772 438.242 138.298 446.5 180.5C451.569 193.71 452.998 202.069 461.977 215C475.653 234.694 482.5 241 506.73 248.201C556.392 258.079 563.65 191.762 612.508 200C642.5 200 670.871 211.259 679.5 215C688.129 218.741 717.89 252.019 721.5 262.5C722.437 266.717 733.419 294.747 729 312.521C727.811 327.883 723.501 348.23 713 363C705.916 376.205 673.832 398.332 659.945 407.909L659.295 408.357C642.011 417.222 631.877 420.803 612.508 423.151Z";
 
   // Public control methods for parent components
   public async Task PlayLapsAsync(int laps, int? speed = null, bool haltOnFinish = true)

--- a/MotorsportsPhysics/Components/Shared/RaceTrack.razor
+++ b/MotorsportsPhysics/Components/Shared/RaceTrack.razor
@@ -127,8 +127,8 @@
   protected override async Task OnAfterRenderAsync(bool firstRender)
   {
     if (!firstRender) return;
-  _module = await JS.InvokeAsync<IJSObjectReference>("import", "/js/trackSim.js?v=19");
-  _anim = await _module.InvokeAsync<IJSObjectReference>("init", svg, new { speed = this.Speed, startRotation = this.StartRotation, angleSmoothing = this.AngleSmoothing, startOffsetFrac = this.StartOffsetFraction, showStartMarker = this.ShowStartMarker });
+  _module = await JS.InvokeAsync<IJSObjectReference>("import", "/js/trackSim.js?v=20");
+  _anim = await _module.InvokeAsync<IJSObjectReference>("init", svg, new { speed = this.Speed, startRotation = this.StartRotation, angleSmoothing = this.AngleSmoothing, startOffsetFrac = this.StartOffsetFraction, showStartMarker = this.ShowStartMarker, gateByAnsweredCount = this.GateByAnsweredCount });
     // Apply optional transform so the path and cars align
     if (_anim is not null && (PathTranslateX != 0 || PathTranslateY != 0 || Math.Abs(PathScale - 1.0) > double.Epsilon))
     {
@@ -240,6 +240,9 @@
   public record CarSprite(string Src, double Width = 70, double Height = 40, double Offset = 0, double GridDx = 0, double GridDy = 0, int Lane = 1);
 
   [Parameter] public bool ShowStartMarker { get; set; } = false;
+  // If true (default), the car will pause at start/finish when the lap number exceeds answered questions.
+  // Set false to disable lap-to-question gating (used for Medium difficulty as requested).
+  [Parameter] public bool GateByAnsweredCount { get; set; } = true;
 
   private string PathD =
     "M612.508 423.151C438.898 431.914 342.384 437.99 157.525 430.869L105.314 425.08C75.8902 420.87 59.5932 415.586 30.7261 403.212L2.24728 372.338C-0.27815 353.794 0.792105 343.641 7.67182 326.028C12.3987 316.855 17.2131 311.847 35.4726 303.516C52.7043 299.586 62.4797 297.497 89.718 303.516C101.939 305.194 112.634 312.46 139.895 338.892C186.892 355.437 189.833 355.243 196.853 355.615C225.262 355.854 241.088 356.2 271.44 352.399C288.644 345.87 298.524 342.547 312.802 331.817C323.327 322.255 329.179 316.875 336.535 306.089C340.464 295.428 342.557 289.419 345.35 278.432C348.644 263.111 348.231 253.314 345.35 234.694C336.411 223.188 329.636 217.788 316.193 208.966C301.988 200.751 291.955 196.688 270.762 190.314C238.172 177.054 220.704 168.949 192.106 152.365C181.637 146.763 176.722 142.797 171.764 132.426V111.201V75.8249C175.638 56.9734 179.604 47.1064 198.209 34.0172C229.62 14.5551 250.567 9.50283 289.07 2.50056C322.807 -0.953666 340.821 2.07071 373.15 6.35973C386.721 10.1824 394.257 12.7043 407.054 20.51C417.914 27.5802 425.656 33.3101 438.245 48.8107C446.837 60.4237 448.531 66.6711 451.806 79.6841C452.001 123.435 453.647 147.742 461.977 190.314C467.046 203.524 471.306 210.829 480.285 223.76C492.701 243.258 502.201 247.655 506.73 248.201C556.392 258.079 583.992 263.118 632.851 271.356C652.515 279.189 676.673 291.56 685.062 296.441C693.451 301.322 696.107 303.287 699.979 312.521C700.986 324.059 701.654 330.603 699.979 340.178C696.576 355.747 693.369 364.21 685.062 378.77C677.865 392.185 672.803 399.039 659.295 408.357C642.011 417.222 631.877 420.803 612.508 423.151Z";
@@ -287,6 +290,7 @@
     {
       try { await _anim.InvokeVoidAsync("setQuestionAnswered", QuestionAnswered); } catch { }
       try { await _anim.InvokeVoidAsync("setAnsweredCount", AnsweredCount); } catch { }
+      try { await _anim.InvokeVoidAsync("setGateByAnsweredCount", GateByAnsweredCount); } catch { }
     }
   }
 

--- a/MotorsportsPhysics/Components/Shared/RaceTrack.razor
+++ b/MotorsportsPhysics/Components/Shared/RaceTrack.razor
@@ -117,11 +117,17 @@
   private string _speedDisplay => _speedCurrent.ToString(System.Globalization.CultureInfo.InvariantCulture);
   private int _lapCurrent = 0;
   private string _lapDisplay => (_lapCurrent + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+  // Rank DTO to mirror JS getUserRank() result
+  public record RaceRank(int Position, int TotalCars);
+  public record CoveredDistance(int Idx, string Id, bool IsUser, double DistancePx, double? FractionOfRace);
+  public record LapSample(int Idx, string Id, bool IsUser, string Color, double DistancePx);
+  public record LapTelemetry(int Lap, double ElapsedMs, List<LapSample> Samples);
+
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
   {
     if (!firstRender) return;
-  _module = await JS.InvokeAsync<IJSObjectReference>("import", "/js/trackSim.js?v=18");
+  _module = await JS.InvokeAsync<IJSObjectReference>("import", "/js/trackSim.js?v=19");
   _anim = await _module.InvokeAsync<IJSObjectReference>("init", svg, new { speed = this.Speed, startRotation = this.StartRotation, angleSmoothing = this.AngleSmoothing, startOffsetFrac = this.StartOffsetFraction, showStartMarker = this.ShowStartMarker });
     // Apply optional transform so the path and cars align
     if (_anim is not null && (PathTranslateX != 0 || PathTranslateY != 0 || Math.Abs(PathScale - 1.0) > double.Epsilon))
@@ -331,6 +337,13 @@
     await _anim.InvokeVoidAsync("adjustBaseSpeed", delta);
   }
 
+  // Set the constant base speed to an absolute value (px/s)
+  public async Task SetBaseSpeedAsync(double absolute)
+  {
+    if (_anim is null) return;
+    await _anim.InvokeVoidAsync("setSpeed", absolute);
+  }
+
   // Public start entry: ensure playing and run the configured delay + ramp to current Speed
   public async Task StartAsync(double? targetSpeed = null)
   {
@@ -350,5 +363,60 @@
     try { _cts?.Cancel(); } catch { }
     await _anim.InvokeVoidAsync("setSpeed", 0);
     await _anim.InvokeVoidAsync("pause");
+  }
+
+  // Query current user position among all cars (1-based) and the total car count
+  public async Task<RaceRank> GetUserRankAsync()
+  {
+    if (_anim is null)
+    {
+      return new RaceRank(1, 1);
+    }
+    try
+    {
+      var r = await _anim.InvokeAsync<RaceRank>("getUserRank");
+      return r ?? new RaceRank(1, 1);
+    }
+    catch
+    {
+      return new RaceRank(1, 1);
+    }
+  }
+
+  public async Task<List<CoveredDistance>> GetCoveredDistancesAsync()
+  {
+    if (_anim is null) return new List<CoveredDistance>();
+    try
+    {
+      var arr = await _anim.InvokeAsync<CoveredDistance[]>("getCoveredDistances");
+      return arr?.ToList() ?? new List<CoveredDistance>();
+    }
+    catch
+    {
+      return new List<CoveredDistance>();
+    }
+  }
+
+  public async Task SetTargetLapsAsync(int laps)
+  {
+    if (_anim is null) return;
+    await _anim.InvokeVoidAsync("setTargetLaps", laps);
+  }
+
+  public async Task<List<LapTelemetry>> GetLapTelemetryAsync()
+  {
+    if (_anim is null) return new List<LapTelemetry>();
+    try
+    {
+      var arr = await _anim.InvokeAsync<LapTelemetry[]>("getLapTelemetry");
+      return arr?.ToList() ?? new List<LapTelemetry>();
+    }
+    catch { return new List<LapTelemetry>(); }
+  }
+
+  public async Task ResetLapTelemetryAsync()
+  {
+    if (_anim is null) return;
+    try { await _anim.InvokeVoidAsync("resetLapTelemetry"); } catch { }
   }
 }

--- a/MotorsportsPhysics/wwwroot/js/trackSim.js
+++ b/MotorsportsPhysics/wwwroot/js/trackSim.js
@@ -7,11 +7,11 @@
  */
 export function init(svgEl, opts = {}) {
   // DEBUG logging toggle
-  const DEBUG = true;
+  const DEBUG = false;
   const dlog = (...args) => { try { if (DEBUG) console.log('[trackSim]', ...args); } catch { /* ignore */ } };
-  // TEMP TEST: globally force a hard stop after the first lap even if playForLaps isn't called
-  const FORCE_FIRST_LAP_TEST = false;
-  let testTickerAttached = false;
+  // Internal test scaffolding removed for production
+  const FORCE_FIRST_LAP_TEST = false; // deprecated
+  let testTickerAttached = false; // deprecated
   const speed = opts.speed ?? 140; // px / s along path length
   const path = /** @type {SVGPathElement} */ (svgEl.querySelector('#racePath'));
   const path2 = /** @type {SVGPathElement} */ (svgEl.querySelector('#racePath2'));


### PR DESCRIPTION
This pull request significantly enhances the "Medium" difficulty mode of the Cornering Quiz, introducing a five-rival race experience with new question sets, improved UI feedback, and tighter integration between the quiz and race logic. The changes make the quiz more engaging and dynamic, especially in race scenarios, and provide a scalable structure for future difficulty levels.

**Medium Difficulty Race Mode Enhancements**

* The quiz now supports five rivals in Medium mode, each with customizable labels and their own progress bars. Rival progress and placement logic have been updated to reflect the new structure. [[1]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R109-R116) [[2]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R251-R268) [[3]](diffhunk://#diff-265faaedc5b31aacfa586efa1303d2a077ea181b6b198bc89eddafaefbb2de16R159) [[4]](diffhunk://#diff-265faaedc5b31aacfa586efa1303d2a077ea181b6b198bc89eddafaefbb2de16R169)
* Added a dedicated set of Medium-difficulty questions, distinct from the Easy set, and logic to select the appropriate set based on the selected difficulty. [[1]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R227-R228) [[2]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R322-R405) [[3]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R598-R607)
* The UI for Medium mode now displays the user's race result with correct placement and total cars, using either internal or external placement data. [[1]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R195-R211) [[2]](diffhunk://#diff-265faaedc5b31aacfa586efa1303d2a077ea181b6b198bc89eddafaefbb2de16R93)

**Quiz and Race Integration Improvements**

* Added new public methods (`SetExternalProgress`, `SetExternalPlacement`, etc.) to allow the parent race component to control quiz state, synchronize progress, and set authoritative race results. [[1]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R574-R588) [[2]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R652-R659)
* The quiz now receives rival labels and difficulty as parameters, making it more flexible and reusable in different race modes. [[1]](diffhunk://#diff-265faaedc5b31aacfa586efa1303d2a077ea181b6b198bc89eddafaefbb2de16L29-R42) [[2]](diffhunk://#diff-265faaedc5b31aacfa586efa1303d2a077ea181b6b198bc89eddafaefbb2de16R127-R132) [[3]](diffhunk://#diff-265faaedc5b31aacfa586efa1303d2a077ea181b6b198bc89eddafaefbb2de16R179)

**User Experience and UI Updates**

* Updated instructions, menu descriptions, and result screens to clearly explain the new Medium mode mechanics, including the continuous race, rival count, and answer effects. [[1]](diffhunk://#diff-a764937e82838a6dfc078d334a7b683e7ee1ee1a48f6107ed851fe8516aa61c1L21-R21) [[2]](diffhunk://#diff-265faaedc5b31aacfa586efa1303d2a077ea181b6b198bc89eddafaefbb2de16R53-R78)
* The "Next"/"Finish" button is now disabled until the race is complete, ensuring proper flow in RaceMode.

**Technical and Codebase Improvements**

* Refactored initialization and reset logic to handle multiple rivals and question sets, and to ensure clean state transitions between races. [[1]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5R457-R458) [[2]](diffhunk://#diff-8179a39ec6f48498510780317524e3d0370b10b84e26e327b91c6ac245ca9de5L357-R470)
* Added `System.Linq` import for collection operations needed by the new logic.